### PR TITLE
Multi hosts and variables

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -1,9 +1,18 @@
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { MyDataSourceOptions, MyQuery } from './types';
+import { getTemplateSrv } from '@grafana/runtime';
 
 export class DataSource extends DataSourceWithBackend<MyQuery, MyDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<MyDataSourceOptions>) {
     super(instanceSettings);
+  }
+  applyTemplateVariables(query: MyQuery) {
+    const templateSrv = getTemplateSrv();
+    return {
+      ...query,
+      queryText: query.queryText ? templateSrv.replace(query.queryText) : '',
+      queryHost: query.queryHost ? templateSrv.replace(query.queryHost) : '',
+    };
   }
 }


### PR DESCRIPTION
This series addresses two issues:
1. adds support for sending multiple hosts in the host query as a comma-separated list
2. apply template variables before sending the query to the backend.

When specifying a host an additional parameter would be added to the result called _host with the host the results came from.

This is an example of using both a variable parameter and multiple hosts.
![image](https://user-images.githubusercontent.com/2118079/90977258-bc70b680-e54c-11ea-8aa5-37a187b99c90.png)

Fixes #10 