### PR TITLE
Add TLS/mTLS support for GoCQL connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ for example, if you are using Grafana with containers, add:
 -e "GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS=scylladb-scylla-datasource"
 ```
 
-You can now add the scylla data source, the only current configuration is a host in the cluster.
+You can now add the scylla data source. You may configure a host in the cluster to
+connect to by default; alternatively the host can be supplied per query and the cluster
+connection is created on demand. Optional configuration includes username/password
+authentication and TLS/mTLS (see below).
 
 When adding a panel use CQL to get the data.
 you can only do select statements, but any valid select would work.
@@ -62,6 +65,39 @@ To support user and password add `secureJsonData` to `grafana/datasource.yml`
     password: 'cassandra'
 ```
 
+### TLS / mTLS
+
+To connect to a cluster that requires encryption in transit, or mutual TLS
+client-certificate authentication, set `enableTls` in `jsonData` along with
+the paths (on the Grafana server's filesystem, not the browser) to the
+relevant PEM files:
+
+Note: the default installation runs Grafana in a Docker container, so the
+certificate files must be mounted into the container, e.g.
+`-v /path/to/certs:/etc/grafana/certs`.
+
+```
+- name: scylla-datasource
+  type: scylladb-scylla-datasource
+  orgId: 1
+  isDefault:
+  jsonData:
+    host: 'node-ip'
+    enableTls: true
+    tlsCaCertPath: '/etc/grafana/certs/ca.pem'
+    tlsClientCertPath: '/etc/grafana/certs/client-cert.pem'
+    tlsClientKeyPath: '/etc/grafana/certs/client-key.pem'
+    tlsSkipVerify: false
+```
+
+* `enableTls` - enables TLS for the connection; required for any of the other TLS fields to take effect.
+* `tlsCaCertPath` - path to a CA certificate used to verify the server's certificate. Optional; omit to use the system trust store.
+* `tlsClientCertPath` / `tlsClientKeyPath` - paths to a client certificate/key pair, required together for mutual TLS (mTLS). Leave both empty for plain TLS without client authentication.
+* `tlsSkipVerify` - when `true`, disables server certificate/hostname verification. Not recommended outside of testing.
+
+TLS/mTLS can be combined with `user`/`password` authentication from
+`secureJsonData` above; the two are independent settings.
+
 ### Configure the Datasource using Grafana API:
 Grafana API allows adding datasource.
 The following will add a data source without a username and password, replace the `ADMIN_PASSWORD`
@@ -80,6 +116,17 @@ curl -XPOST -i http://admin:$ADMIN_PASSWORD@localhost:3000/api/datasources \
      "jsonData":{"host": ""}, "secureJsonData":{"user": "scylla", "password": "scylla"}}' \
       -H "Content-Type: application/json"
 ```
+
+The following example shows how to configure the plugin with TLS/mTLS, using
+paths to PEM files on the Grafana server:
+```
+curl -XPOST -i http://admin:$ADMIN_PASSWORD@localhost:3000/api/datasources \
+     --data-binary '{"name": "scylla-datasource","type": "scylladb-scylla-datasource", "orgId": 1,"access":"proxy", \
+     "jsonData":{"host": "", "enableTls": true, "tlsCaCertPath": "/etc/grafana/certs/ca.pem", \
+     "tlsClientCertPath": "/etc/grafana/certs/client-cert.pem", "tlsClientKeyPath": "/etc/grafana/certs/client-key.pem"}}' \
+      -H "Content-Type: application/json"
+```
+
 
 ## Compiling the data source by yourself
 A data source backend plugin consists of both frontend and backend components.

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -39,9 +39,34 @@ var (
 	_ instancemgmt.InstanceDisposer = (*Datasource)(nil)
 )
 
+// buildSslOpts constructs gocql.SslOptions from the configured paths, validating
+// that the client cert and key are provided as a pair. gocql calls
+// tls.LoadX509KeyPair when either path is set, so a partial mTLS configuration
+// would otherwise fail later, deep inside session creation, with a confusing
+// low-level file error.
+func buildSslOpts(enableTls bool, caCertPath, clientCertPath, clientKeyPath string, skipVerify bool) (*gocql.SslOptions, error) {
+	if !enableTls {
+		return nil, nil
+	}
+	if (clientCertPath == "") != (clientKeyPath == "") {
+		return nil, errors.New("TLS client cert path and client key path must both be set for mTLS, or both left empty")
+	}
+	return &gocql.SslOptions{
+		CertPath:               clientCertPath,
+		KeyPath:                clientKeyPath,
+		CaPath:                 caCertPath,
+		EnableHostVerification: !skipVerify,
+	}, nil
+}
+
 func getDatasourceSettings(setting backend.DataSourceInstanceSettings) (*instanceSettings, error) {
 	type editModel struct {
-		Host string `json:"host"`
+		Host              string `json:"host"`
+		EnableTls         bool   `json:"enableTls"`
+		TlsCaCertPath     string `json:"tlsCaCertPath"`
+		TlsClientCertPath string `json:"tlsClientCertPath"`
+		TlsClientKeyPath  string `json:"tlsClientKeyPath"`
+		TlsSkipVerify     bool   `json:"tlsSkipVerify"`
 	}
 	var hosts editModel
 	log.DefaultLogger.Debug("newDataSourceInstance", "data", setting.JSONData)
@@ -63,16 +88,22 @@ func getDatasourceSettings(setting backend.DataSourceInstanceSettings) (*instanc
 			Password: password,
 		}
 	}
+	sslOpts, err := buildSslOpts(hosts.EnableTls, hosts.TlsCaCertPath, hosts.TlsClientCertPath, hosts.TlsClientKeyPath, hosts.TlsSkipVerify)
+	if err != nil {
+		return nil, err
+	}
 	if hosts.Host != "" {
 		newCluster = gocql.NewCluster(hosts.Host)
 		if authenticator != nil {
 			newCluster.Authenticator = *authenticator
 		}
+		newCluster.SslOpts = sslOpts
 		newCluster.Consistency = gocql.LocalOne
 	}
 	return &instanceSettings{
 		cluster:       newCluster,
 		authenticator: authenticator,
+		sslOpts:       sslOpts,
 		sessions:      make(map[string]*gocql.Session),
 		clusters:      make(map[string]*gocql.ClusterConfig),
 	}, nil
@@ -312,6 +343,7 @@ func (t *customAddressTranslator) Translate(ip net.IP, port int) (net.IP, int) {
 type instanceSettings struct {
 	cluster       *gocql.ClusterConfig
 	authenticator *gocql.PasswordAuthenticator
+	sslOpts       *gocql.SslOptions
 	sessions      map[string]*gocql.Session
 	clusters      map[string]*gocql.ClusterConfig
 }
@@ -493,12 +525,14 @@ func (settings *instanceSettings) getSession(hostRef interface{}, specificHost b
 		if settings.authenticator != nil {
 			settings.clusters[host].Authenticator = *settings.authenticator
 		}
+		settings.clusters[host].SslOpts = settings.sslOpts
 		if settings.cluster == nil {
 			// good opportunity to create a default cluster
 			settings.cluster = gocql.NewCluster(host)
 			if settings.authenticator != nil {
 				settings.cluster.Authenticator = *settings.authenticator
 			}
+			settings.cluster.SslOpts = settings.sslOpts
 			settings.cluster.Consistency = gocql.LocalOne
 		}
 

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -1,5 +1,5 @@
 import React, { ChangeEvent } from 'react';
-import { InlineField, Input, SecretInput } from '@grafana/ui';
+import { InlineField, InlineSwitch, Input, SecretInput } from '@grafana/ui';
 import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { MyDataSourceOptions, MySecureJsonData } from '../types';
 
@@ -61,6 +61,46 @@ export function ConfigEditor(props: Props) {
     });
   };
 
+  const onEnableTlsChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const jsonData = {
+      ...options.jsonData,
+      enableTls: event.target.checked,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
+  const onTlsSkipVerifyChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const jsonData = {
+      ...options.jsonData,
+      tlsSkipVerify: event.target.checked,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
+  const onTlsCaCertPathChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const jsonData = {
+      ...options.jsonData,
+      tlsCaCertPath: event.target.value,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
+  const onTlsClientCertPathChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const jsonData = {
+      ...options.jsonData,
+      tlsClientCertPath: event.target.value,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
+  const onTlsClientKeyPathChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const jsonData = {
+      ...options.jsonData,
+      tlsClientKeyPath: event.target.value,
+    };
+    onOptionsChange({ ...options, jsonData });
+  };
+
   const { jsonData, secureJsonFields } = options;
   const secureJsonData = (options.secureJsonData || {}) as MySecureJsonData;
 
@@ -97,6 +137,40 @@ export function ConfigEditor(props: Props) {
           onChange={onPasswordChange}
         />
       </InlineField>
+      <InlineField label="Enable TLS" labelWidth={12}>
+        <InlineSwitch value={!!jsonData.enableTls} onChange={onEnableTlsChange} />
+      </InlineField>
+      {jsonData.enableTls && (
+        <>
+          <InlineField label="Skip TLS verify" labelWidth={12}>
+            <InlineSwitch value={!!jsonData.tlsSkipVerify} onChange={onTlsSkipVerifyChange} />
+          </InlineField>
+          <InlineField label="CA cert path" labelWidth={12}>
+            <Input
+              onChange={onTlsCaCertPathChange}
+              value={jsonData.tlsCaCertPath || ''}
+              placeholder="/path/to/ca.pem (on the Grafana server)"
+              width={40}
+            />
+          </InlineField>
+          <InlineField label="Client cert path" labelWidth={12}>
+            <Input
+              onChange={onTlsClientCertPathChange}
+              value={jsonData.tlsClientCertPath || ''}
+              placeholder="/path/to/client-cert.pem (for mTLS)"
+              width={40}
+            />
+          </InlineField>
+          <InlineField label="Client key path" labelWidth={12}>
+            <Input
+              onChange={onTlsClientKeyPathChange}
+              value={jsonData.tlsClientKeyPath || ''}
+              placeholder="/path/to/client-key.pem (for mTLS)"
+              width={40}
+            />
+          </InlineField>
+        </>
+      )}
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,11 @@ export const DEFAULT_QUERY: Partial<MyQuery> = {
  */
 export interface MyDataSourceOptions extends DataSourceJsonData {
   host?: string;
+  enableTls?: boolean;
+  tlsCaCertPath?: string;
+  tlsClientCertPath?: string;
+  tlsClientKeyPath?: string;
+  tlsSkipVerify?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add TLS/mTLS support for GoCQL connections

Motivation:
The datasource previously only supported username/password authentication. Clusters requiring encryption in transit (TLS) or mutual TLS client-certificate authentication had no way to configure this,
so connecting to such clusters was not possible. ScyllaDB 2026.4 will add mTLS support for encryption/authentication.

Change:
- pkg/plugin/datasource.go: read new JSONData fields (enableTls, tlsCaCertPath, tlsClientCertPath, tlsClientKeyPath, tlsSkipVerify)
  and build a gocql.SslOptions from them (file paths on the Grafana server, consistent with gocql's native CertPath/KeyPath/CaPath).
  Apply it in both getDatasourceSettings and getSession, alongside the existing PasswordAuthenticator, so TLS/mTLS and username/password auth can be combined independently.
- src/types.ts: expose the new TLS options on MyDataSourceOptions.
- src/components/ConfigEditor.tsx: add an "Enable TLS" switch plus conditional "Skip TLS verify" switch and CA/client cert/client key path inputs in the config editor.

Tests:
- go build ./... and go vet ./... (backend compiles clean)
- npm run typecheck (frontend types check clean)
No live-cluster integration test was run in this session.

Results:
- Backend build: clean, no errors.
- go vet: no findings.
- Frontend typecheck: clean, no errors.
