### PR TITLE
fix: build cluster from query hosts when connection scope is any

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,34 @@ To support user and password add `secureJsonData` to `grafana/datasource.yml`
     password: 'cassandra'
 ```
 
+### Connection scope and query hosts
+
+`connectionScope` in `jsonData` controls which hosts a query may be routed to:
+
+* `cluster_only` (default) - queries may target any node of the cluster reached through `host`. A query host that is not part of that cluster is rejected.
+* `specified_list` - queries may only target nodes listed in `host`. A query host is required.
+* `any` - no restriction on the query host. This is the only scope that allows `host` to be left empty:
+
+```
+- name: scylla-datasource
+  type: scylladb-scylla-datasource
+  orgId: 1
+  isDefault:
+  jsonData:
+    host: ''
+    connectionScope: 'any'
+```
+
+With this configuration the connection is created on demand from the hosts supplied by the
+first query (for example a `queryHost` bound to a dashboard variable), which is how
+Scylla-Monitoring uses the plugin.
+
+A datasource instance holds a single connection and therefore serves a **single cluster** in
+every connection scope. With `any` and an empty `host`, the first query's hosts decide which
+cluster that is; hosts from another cluster in later queries fail to resolve until the
+connection is re-established (a datasource settings change or a Grafana restart). To query
+several clusters, configure one datasource per cluster.
+
 ### TLS / mTLS
 
 To connect to a cluster that requires encryption in transit, or mutual TLS

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -667,10 +667,13 @@ func (settings *instanceSettings) getSession() (*gocql.Session, error) {
 	return settings.getSessionWithHosts(nil)
 }
 
-// getSessionWithHosts returns the shared session, creating it on first use. queryHosts are
-// only consulted when the datasource has no configured hosts and connection scope is "any";
-// the lazily built cluster is deliberately not stored, so a later reconnect uses the hosts of
-// the query that triggers it rather than whichever query happened to come first.
+// getSessionWithHosts returns the shared session, creating it on first use. A datasource
+// instance holds a single session and therefore serves a single cluster in every connection
+// scope. queryHosts are only consulted when the datasource has no configured hosts and the
+// connection scope is "any": the first query's hosts pick the cluster, and as long as that
+// session is live all later queries reuse it regardless of the hosts they name, so hosts from
+// a different cluster fail to resolve against its metadata. Only once the session is closed
+// is the cluster rebuilt, from the hosts of the query that triggers the reconnect.
 func (settings *instanceSettings) getSessionWithHosts(queryHosts []string) (*gocql.Session, error) {
 	if r := recover(); r != nil {
 		log.DefaultLogger.Info("Recovered in getSession", "error", r)

--- a/pkg/plugin/datasource.go
+++ b/pkg/plugin/datasource.go
@@ -99,7 +99,6 @@ func getDatasourceSettings(setting backend.DataSourceInstanceSettings) (*instanc
 	if connectionScope != connectionScopeAny && len(configuredHosts) == 0 {
 		return nil, errors.New("host list cannot be empty when connection scope is not any")
 	}
-	var newCluster *gocql.ClusterConfig = nil
 	var authenticator *gocql.PasswordAuthenticator = nil
 	password, hasPassword := secureData["password"]
 	user, hasUser := secureData["user"]
@@ -114,27 +113,19 @@ func getDatasourceSettings(setting backend.DataSourceInstanceSettings) (*instanc
 	if err != nil {
 		return nil, err
 	}
-	if len(configuredHosts) > 0 {
-		newCluster = gocql.NewCluster(configuredHosts...)
-		if authenticator != nil {
-			newCluster.Authenticator = *authenticator
-		}
-		newCluster.SslOpts = sslOpts
-		newCluster.Consistency = gocql.LocalOne
-		switch connectionScope {
-		case connectionScopeSpecified:
-			newCluster.HostFilter = gocql.WhiteListHostFilter(configuredHosts...)
-		default:
-			newCluster.HostFilter = gocql.AcceptAllFilter()
-		}
-	}
-	return &instanceSettings{
-		cluster:         newCluster,
+	settings := &instanceSettings{
 		authenticator:   authenticator,
+		sslOpts:         sslOpts,
 		host:            hosts.Host,
 		connectionScope: connectionScope,
 		configuredHosts: configuredHosts,
-	}, nil
+	}
+	// With connection scope "any" the host list may be left empty, in which case the
+	// cluster is built lazily from the hosts each query supplies (see clusterForSession).
+	if len(configuredHosts) > 0 {
+		settings.cluster = settings.newClusterConfig(configuredHosts)
+	}
+	return settings, nil
 }
 
 // Datasource
@@ -276,7 +267,7 @@ func (td *Datasource) query(_ context.Context, pCtx backend.PluginContext, insta
 			hostRef string
 		}
 
-		session, err := instance.getSession()
+		session, err := instance.getSessionWithHosts(hostList)
 		if err != nil {
 			log.DefaultLogger.Warn("Failed getting session", "err", err)
 			response.Error = err
@@ -406,6 +397,13 @@ func (td *Datasource) query(_ context.Context, pCtx backend.PluginContext, insta
 func (d *Datasource) CheckHealth(_ context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
 	var status = backend.HealthStatusOk
 	var message = "Data source is working"
+	// Nothing to connect to yet: with scope "any" the hosts arrive with each query.
+	if d.settings.cluster == nil && d.settings.connectionScope == connectionScopeAny {
+		return &backend.CheckHealthResult{
+			Status:  status,
+			Message: "No host configured; connections will use the hosts supplied by each query (connection scope: any)",
+		}, nil
+	}
 	_, err := d.settings.getSession()
 	if err != nil {
 		log.DefaultLogger.Warn("Failed getting session", "err", err)
@@ -434,9 +432,44 @@ type instanceSettings struct {
 	session         *gocql.Session
 	disposed        bool
 	authenticator   *gocql.PasswordAuthenticator
+	sslOpts         *gocql.SslOptions
 	host            string
 	connectionScope string
 	configuredHosts []string
+}
+
+// newClusterConfig builds the gocql cluster config for the given contact points, applying
+// the datasource's authentication, TLS and host filter settings. Both the configured host
+// list and the per-query host list go through here so the two paths cannot drift apart.
+func (settings *instanceSettings) newClusterConfig(hosts []string) *gocql.ClusterConfig {
+	cluster := gocql.NewCluster(hosts...)
+	if settings.authenticator != nil {
+		cluster.Authenticator = *settings.authenticator
+	}
+	cluster.SslOpts = settings.sslOpts
+	cluster.Consistency = gocql.LocalOne
+	switch settings.connectionScope {
+	case connectionScopeSpecified:
+		cluster.HostFilter = gocql.WhiteListHostFilter(hosts...)
+	default:
+		cluster.HostFilter = gocql.AcceptAllFilter()
+	}
+	return cluster
+}
+
+// clusterForSession decides which cluster config a new session should be built from.
+// A datasource with configured hosts always uses those. Without configured hosts, only
+// connection scope "any" may fall back to the hosts supplied by the query; the stricter
+// scopes are defined in terms of the configured list, so they have nothing to check
+// query hosts against and must fail instead.
+func (settings *instanceSettings) clusterForSession(queryHosts []string) (*gocql.ClusterConfig, error) {
+	if settings.cluster != nil {
+		return settings.cluster, nil
+	}
+	if settings.connectionScope == connectionScopeAny && len(queryHosts) > 0 {
+		return settings.newClusterConfig(queryHosts), nil
+	}
+	return nil, errors.New("no host supplied for connection: configure a host on the datasource, or use connection scope any and set a host on the query")
 }
 
 func parseHostList(hosts string) []string {
@@ -631,6 +664,14 @@ func (settings *instanceSettings) getHostIDByAddress(host string) (string, bool,
 }
 
 func (settings *instanceSettings) getSession() (*gocql.Session, error) {
+	return settings.getSessionWithHosts(nil)
+}
+
+// getSessionWithHosts returns the shared session, creating it on first use. queryHosts are
+// only consulted when the datasource has no configured hosts and connection scope is "any";
+// the lazily built cluster is deliberately not stored, so a later reconnect uses the hosts of
+// the query that triggers it rather than whichever query happened to come first.
+func (settings *instanceSettings) getSessionWithHosts(queryHosts []string) (*gocql.Session, error) {
 	if r := recover(); r != nil {
 		log.DefaultLogger.Info("Recovered in getSession", "error", r)
 		var err error = nil
@@ -652,12 +693,13 @@ func (settings *instanceSettings) getSession() (*gocql.Session, error) {
 	if settings.session != nil && !settings.session.Closed() {
 		return settings.session, nil
 	}
-	if settings.cluster == nil {
-		return nil, errors.New("no host supplied for connection")
-	}
-	session, err := gocql.NewSession(*settings.cluster)
+	cluster, err := settings.clusterForSession(queryHosts)
 	if err != nil {
-		log.DefaultLogger.Info("unable to connect to scylla", "err", err, "clusterHosts", settings.cluster.Hosts)
+		return nil, err
+	}
+	session, err := gocql.NewSession(*cluster)
+	if err != nil {
+		log.DefaultLogger.Info("unable to connect to scylla", "err", err, "clusterHosts", cluster.Hosts)
 		return nil, err
 	}
 	log.DefaultLogger.Debug("Session created successfully")

--- a/pkg/plugin/datasource_test.go
+++ b/pkg/plugin/datasource_test.go
@@ -1,0 +1,174 @@
+package plugin
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gocql/gocql"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+)
+
+func TestParseHostList(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"172.17.0.2", []string{"172.17.0.2"}},
+		{"172.17.0.2,172.17.0.3", []string{"172.17.0.2", "172.17.0.3"}},
+		// Grafana's default (glob) formatting of a multi value variable.
+		{"{172.17.0.2,172.17.0.3}", []string{"172.17.0.2", "172.17.0.3"}},
+		{" 172.17.0.2 , ,172.17.0.3 ", []string{"172.17.0.2", "172.17.0.3"}},
+	}
+	for _, c := range cases {
+		got := parseHostList(c.in)
+		if strings.Join(got, "|") != strings.Join(c.want, "|") {
+			t.Errorf("parseHostList(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeConnectionScope(t *testing.T) {
+	cases := map[string]string{
+		"":               connectionScopeClusterOnly,
+		"bogus":          connectionScopeClusterOnly,
+		"cluster_only":   connectionScopeClusterOnly,
+		"specified_list": connectionScopeSpecified,
+		"any":            connectionScopeAny,
+	}
+	for in, want := range cases {
+		if got := normalizeConnectionScope(in); got != want {
+			t.Errorf("normalizeConnectionScope(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func settingsFromJSON(t *testing.T, jsonData string) (*instanceSettings, error) {
+	t.Helper()
+	return getDatasourceSettings(backend.DataSourceInstanceSettings{
+		JSONData:                json.RawMessage(jsonData),
+		DecryptedSecureJSONData: map[string]string{},
+	})
+}
+
+func TestGetDatasourceSettings(t *testing.T) {
+	t.Run("no host with default scope is rejected", func(t *testing.T) {
+		if _, err := settingsFromJSON(t, `{"host":""}`); err == nil {
+			t.Fatal("expected an error for empty host with cluster_only scope")
+		}
+	})
+
+	t.Run("no host with specified_list scope is rejected", func(t *testing.T) {
+		if _, err := settingsFromJSON(t, `{"host":"","connectionScope":"specified_list"}`); err == nil {
+			t.Fatal("expected an error for empty host with specified_list scope")
+		}
+	})
+
+	t.Run("no host with any scope is accepted without a cluster", func(t *testing.T) {
+		s, err := settingsFromJSON(t, `{"host":"","connectionScope":"any"}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.cluster != nil {
+			t.Fatal("expected no cluster to be built when no host is configured")
+		}
+		if s.connectionScope != connectionScopeAny {
+			t.Fatalf("connectionScope = %q, want any", s.connectionScope)
+		}
+	})
+
+	t.Run("configured hosts build the cluster", func(t *testing.T) {
+		s, err := settingsFromJSON(t, `{"host":"10.0.0.1,10.0.0.2"}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if s.cluster == nil {
+			t.Fatal("expected a cluster to be built from the configured hosts")
+		}
+		if strings.Join(s.cluster.Hosts, ",") != "10.0.0.1,10.0.0.2" {
+			t.Fatalf("cluster hosts = %v", s.cluster.Hosts)
+		}
+	})
+}
+
+func TestClusterForSession(t *testing.T) {
+	queryHosts := []string{"172.17.0.2", "172.17.0.3"}
+
+	t.Run("configured cluster wins regardless of query hosts", func(t *testing.T) {
+		s := &instanceSettings{connectionScope: connectionScopeAny, configuredHosts: []string{"10.0.0.1"}}
+		s.cluster = s.newClusterConfig(s.configuredHosts)
+
+		got, err := s.clusterForSession(queryHosts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != s.cluster {
+			t.Fatal("expected the configured cluster to be returned")
+		}
+	})
+
+	t.Run("any scope without configured hosts builds from query hosts", func(t *testing.T) {
+		s := &instanceSettings{connectionScope: connectionScopeAny}
+
+		got, err := s.clusterForSession(queryHosts)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Join(got.Hosts, ",") != strings.Join(queryHosts, ",") {
+			t.Fatalf("cluster hosts = %v, want %v", got.Hosts, queryHosts)
+		}
+		if s.cluster != nil {
+			t.Fatal("lazily built cluster must not be stored on the instance")
+		}
+	})
+
+	t.Run("any scope without any hosts at all fails", func(t *testing.T) {
+		s := &instanceSettings{connectionScope: connectionScopeAny}
+		if _, err := s.clusterForSession(nil); err == nil {
+			t.Fatal("expected an error when neither configured nor query hosts exist")
+		}
+	})
+
+	for _, scope := range []string{connectionScopeClusterOnly, connectionScopeSpecified} {
+		t.Run("scope "+scope+" never builds from query hosts", func(t *testing.T) {
+			s := &instanceSettings{connectionScope: scope}
+			if _, err := s.clusterForSession(queryHosts); err == nil {
+				t.Fatalf("expected an error for scope %s with query hosts only", scope)
+			}
+		})
+	}
+}
+
+func TestNewClusterConfigAppliesSettings(t *testing.T) {
+	auth := &gocql.PasswordAuthenticator{Username: "u", Password: "p"}
+	ssl := &gocql.SslOptions{CaPath: "/ca.pem", EnableHostVerification: true}
+
+	t.Run("auth, tls and consistency are applied", func(t *testing.T) {
+		s := &instanceSettings{connectionScope: connectionScopeAny, authenticator: auth, sslOpts: ssl}
+		c := s.newClusterConfig([]string{"10.0.0.1"})
+
+		if got, ok := c.Authenticator.(gocql.PasswordAuthenticator); !ok || got.Username != "u" {
+			t.Fatalf("authenticator not applied: %#v", c.Authenticator)
+		}
+		if c.SslOpts != ssl {
+			t.Fatal("ssl options not applied")
+		}
+		if c.Consistency != gocql.LocalOne {
+			t.Fatalf("consistency = %v, want LocalOne", c.Consistency)
+		}
+	})
+
+	t.Run("specified_list uses a whitelist filter, others accept all", func(t *testing.T) {
+		whitelisted := &instanceSettings{connectionScope: connectionScopeSpecified}
+		open := &instanceSettings{connectionScope: connectionScopeAny}
+
+		if whitelisted.newClusterConfig([]string{"10.0.0.1"}).HostFilter == nil {
+			t.Fatal("expected a host filter for specified_list")
+		}
+		if open.newClusterConfig([]string{"10.0.0.1"}).HostFilter == nil {
+			t.Fatal("expected an accept-all host filter for any")
+		}
+	})
+}


### PR DESCRIPTION
With connection scope "any" the datasource host list may be left empty, which the settings parser already accepted, but getSession still required a cluster built from the configured hosts and failed every query with "no host supplied for connection". Dashboards that pass the target hosts per query (queryHost: "$variable" with allHosts) were therefore broken.

- clusterForSession picks the configured cluster when present, otherwise builds one from the query hosts, but only when scope is "any". The stricter scopes are defined relative to the configured list and still fail as before.
- newClusterConfig is shared by both paths so auth, TLS, consistency and the host filter cannot drift; sslOpts is kept on the instance for that.
- The lazily built cluster is not stored, so a reconnect uses the hosts of the query that triggers it and a failed first query cannot poison later ones.
- CheckHealth reports "any" with no host as a valid configuration.
- Add unit tests for host parsing, scope normalisation, settings acceptance and the clusterForSession decision matrix.